### PR TITLE
Replace check_obj._val with check_obj.value to avoid linter warnings.

### DIFF
--- a/fluentcheck/assertions_check/booleans.py
+++ b/fluentcheck/assertions_check/booleans.py
@@ -3,34 +3,34 @@ from ..exceptions import CheckError
 
 def is_boolean(check_obj):
     try:
-        assert isinstance(check_obj._val, bool)
+        assert isinstance(check_obj.value, bool)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not boolean'.format(check_obj._val))
+        raise CheckError('{} is not boolean'.format(check_obj.value))
 
 
 def is_not_boolean(check_obj):
     try:
-        assert not isinstance(check_obj._val, bool)
+        assert not isinstance(check_obj.value, bool)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is boolean'.format(check_obj._val))
+        raise CheckError('{} is boolean'.format(check_obj.value))
 
 
 def is_truthy(check_obj):
     try:
-        assert check_obj._val
+        assert check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} is falsy'.format(check_obj._val))
+        raise CheckError('{} is falsy'.format(check_obj.value))
 
 
 def is_falsy(check_obj):
     try:
-        assert not check_obj._val
+        assert not check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} is truthy'.format(check_obj._val))
+        raise CheckError('{} is truthy'.format(check_obj.value))
 
 
 def is_not_truthy(check_obj):
@@ -59,17 +59,17 @@ def is_not_false(check_obj):
 
 def has_same_truth_of(check_obj, value):
     try:
-        assert bool(check_obj._val) == bool(value)
+        assert bool(check_obj.value) == bool(value)
         return check_obj
     except AssertionError:
-        raise CheckError('{} has a different truth of {}'.format(check_obj._val,
+        raise CheckError('{} has a different truth of {}'.format(check_obj.value,
                                                                  value))
 
 
 def has_opposite_truth_of(check_obj, value):
     try:
-        assert bool(check_obj._val) != bool(value)
+        assert bool(check_obj.value) != bool(value)
         return check_obj
     except AssertionError:
-        raise CheckError('{} has the same truth of {}'.format(check_obj._val,
+        raise CheckError('{} has the same truth of {}'.format(check_obj.value,
                                                               value))

--- a/fluentcheck/assertions_check/collections.py
+++ b/fluentcheck/assertions_check/collections.py
@@ -3,70 +3,70 @@ from ..exceptions import CheckError
 
 def is_set(check_obj):
     try:
-        assert isinstance(check_obj._val, set)
+        assert isinstance(check_obj.value, set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a set'.format(check_obj._val))
+        raise CheckError('{} is not a set'.format(check_obj.value))
 
 
 def is_not_set(check_obj):
     try:
-        assert not isinstance(check_obj._val, set)
+        assert not isinstance(check_obj.value, set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is a set'.format(check_obj._val))
+        raise CheckError('{} is a set'.format(check_obj.value))
 
 
 def is_subset_of(check_obj, _set):
     check_obj.is_set()
     try:
-        assert check_obj._val.issubset(_set)
+        assert check_obj.value.issubset(_set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not subset of {}'.format(check_obj._val, _set))
+        raise CheckError('{} is not subset of {}'.format(check_obj.value, _set))
 
 
 def is_not_subset_of(check_obj, _set):
     check_obj.is_set()
     try:
-        assert not check_obj._val.issubset(_set)
+        assert not check_obj.value.issubset(_set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is subset of {}'.format(check_obj._val, _set))
+        raise CheckError('{} is subset of {}'.format(check_obj.value, _set))
 
 
 def is_superset_of(check_obj, _set):
     check_obj.is_set()
     try:
-        assert check_obj._val.issuperset(_set)
+        assert check_obj.value.issuperset(_set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not superset of {}'.format(check_obj._val, _set))
+        raise CheckError('{} is not superset of {}'.format(check_obj.value, _set))
 
 
 def is_not_superset_of(check_obj, _set):
     check_obj.is_set()
     try:
-        assert not check_obj._val.issuperset(_set)
+        assert not check_obj.value.issuperset(_set)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is superset of {}'.format(check_obj._val, _set))
+        raise CheckError('{} is superset of {}'.format(check_obj.value, _set))
 
 
 def intersects(check_obj, _set):
     check_obj.is_set()
     try:
-        assert len(check_obj._val.intersection(_set)) != 0
+        assert len(check_obj.value.intersection(_set)) != 0
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not intersect {}'.format(check_obj._val, _set))
+        raise CheckError('{} does not intersect {}'.format(check_obj.value, _set))
 
 
 def not_intersects(check_obj, _set):
     check_obj.is_set()
     try:
-        assert len(check_obj._val.intersection(_set)) == 0
+        assert len(check_obj.value.intersection(_set)) == 0
         return check_obj
     except AssertionError:
-        raise CheckError('{} intersects {}'.format(check_obj._val, _set))
+        raise CheckError('{} intersects {}'.format(check_obj.value, _set))
 

--- a/fluentcheck/assertions_check/dicts.py
+++ b/fluentcheck/assertions_check/dicts.py
@@ -3,18 +3,18 @@ from ..exceptions import CheckError
 
 def is_dict(check_obj):
     try:
-        assert isinstance(check_obj._val, dict)
+        assert isinstance(check_obj.value, dict)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a dict'.format(check_obj._val))
+        raise CheckError('{} is not a dict'.format(check_obj.value))
 
 
 def is_not_dict(check_obj):
     try:
-        assert not isinstance(check_obj._val, dict)
+        assert not isinstance(check_obj.value, dict)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is a dict'.format(check_obj._val))
+        raise CheckError('{} is a dict'.format(check_obj.value))
 
 
 def has_keys(check_obj, *args):
@@ -23,10 +23,10 @@ def has_keys(check_obj, *args):
     try:
         for key in args:
             cur_key = key
-            assert key in check_obj._val
+            assert key in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain key: {}'.format(check_obj._val,
+        raise CheckError('{} does not contain key: {}'.format(check_obj.value,
                                                               cur_key))
 
 
@@ -36,7 +36,7 @@ def has_not_keys(check_obj, *args):
     try:
         for key in args:
             cur_key = key
-            assert not key in check_obj._val
+            assert not key in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} does contains key: {}'.format(check_obj._val, cur_key))
+        raise CheckError('{} does contains key: {}'.format(check_obj.value, cur_key))

--- a/fluentcheck/assertions_check/geo.py
+++ b/fluentcheck/assertions_check/geo.py
@@ -8,7 +8,7 @@ def is_latitude(check_obj):
         check_obj.is_between(-90.0, 90.0)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a valid latitude'.format(check_obj._val))
+        raise CheckError('{} is not a valid latitude'.format(check_obj.value))
 
 
 def is_longitude(check_obj):
@@ -17,22 +17,22 @@ def is_longitude(check_obj):
         check_obj.is_between(-180.0, 180.0)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a valid longitude'.format(check_obj._val))
+        raise CheckError('{} is not a valid longitude'.format(check_obj.value))
 
 
 def is_azimuth(check_obj):
     try:
         check_obj.is_number().is_positive()
     except:
-        raise CheckError('{} is not a valid azimuth'.format(check_obj._val))
+        raise CheckError('{} is not a valid azimuth'.format(check_obj.value))
 
 
 def is_geopoint(check_obj):
     check_obj.is_couple()
     try:
-        first = Check(check_obj._val[0])
+        first = Check(check_obj.value[0])
         first.is_long()
-        second = Check(check_obj._val[1])
+        second = Check(check_obj.value[1])
         second.is_latitude()
     except AssertionError:
-        raise CheckError('{} is not a valid geographic point'.format(check_obj._val))
+        raise CheckError('{} is not a valid geographic point'.format(check_obj.value))

--- a/fluentcheck/assertions_check/numbers.py
+++ b/fluentcheck/assertions_check/numbers.py
@@ -4,158 +4,158 @@ from ..exceptions import CheckError
 
 def is_number(check_obj):
     try:
-        assert isinstance(check_obj._val, check_obj.NUMERIC_TYPES)
+        assert isinstance(check_obj.value, check_obj.NUMERIC_TYPES)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a number'.format(check_obj._val))
+        raise CheckError('{} is not a number'.format(check_obj.value))
 
 
 def is_not_number(check_obj):
     try:
-        assert not isinstance(check_obj._val, check_obj.NUMERIC_TYPES)
+        assert not isinstance(check_obj.value, check_obj.NUMERIC_TYPES)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is a number'.format(check_obj._val))
+        raise CheckError('{} is a number'.format(check_obj.value))
 
 
 def is_integer(check_obj):
     try:
-        assert isinstance(check_obj._val, int)
+        assert isinstance(check_obj.value, int)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not integer'.format(check_obj._val))
+        raise CheckError('{} is not integer'.format(check_obj.value))
 
 
 def is_not_integer(check_obj):
     try:
-        assert not isinstance(check_obj._val, int)
+        assert not isinstance(check_obj.value, int)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is integer'.format(check_obj._val))
+        raise CheckError('{} is integer'.format(check_obj.value))
 
 
 def is_float(check_obj):
     try:
-        assert isinstance(check_obj._val, float)
+        assert isinstance(check_obj.value, float)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not float'.format(check_obj._val))
+        raise CheckError('{} is not float'.format(check_obj.value))
 
 
 def is_not_float(check_obj):
     try:
-        assert not isinstance(check_obj._val, float)
+        assert not isinstance(check_obj.value, float)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is float'.format(check_obj._val))
+        raise CheckError('{} is float'.format(check_obj.value))
 
 
 def is_real(check_obj):
     check_obj.is_number()
     try:
-        assert not isinstance(check_obj._val, complex)
+        assert not isinstance(check_obj.value, complex)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not real'.format(check_obj._val))
+        raise CheckError('{} is not real'.format(check_obj.value))
 
 
 def is_not_real(check_obj):
     check_obj.is_number()
     try:
-        assert isinstance(check_obj._val, complex)
+        assert isinstance(check_obj.value, complex)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is real'.format(check_obj._val))
+        raise CheckError('{} is real'.format(check_obj.value))
 
 
 def is_complex(check_obj):
     try:
-        assert isinstance(check_obj._val, complex)
+        assert isinstance(check_obj.value, complex)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not complex'.format(check_obj._val))
+        raise CheckError('{} is not complex'.format(check_obj.value))
 
 
 def is_not_complex(check_obj):
     try:
-        assert not isinstance(check_obj._val, complex)
+        assert not isinstance(check_obj.value, complex)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is complex'.format(check_obj._val))
+        raise CheckError('{} is complex'.format(check_obj.value))
 
 
 def is_positive(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) > 0.
+        assert float(check_obj.value) > 0.
         return check_obj
     except AssertionError:
-        raise CheckError('{} is zero or negative'.format(check_obj._val))
+        raise CheckError('{} is zero or negative'.format(check_obj.value))
 
 
 def is_not_positive(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) <= 0
+        assert float(check_obj.value) <= 0
         return check_obj
     except AssertionError:
-        raise CheckError('{} is positive'.format(check_obj._val))
+        raise CheckError('{} is positive'.format(check_obj.value))
 
 
 def is_negative(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) < 0.
+        assert float(check_obj.value) < 0.
         return check_obj
     except AssertionError:
-        raise CheckError('{} is zero or positive'.format(check_obj._val))
+        raise CheckError('{} is zero or positive'.format(check_obj.value))
 
 
 def is_not_negative(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) >= 0
+        assert float(check_obj.value) >= 0
         return check_obj
     except AssertionError:
-        raise CheckError('{} is negative'.format(check_obj._val))
+        raise CheckError('{} is negative'.format(check_obj.value))
 
 
 def is_zero(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) == 0.
+        assert float(check_obj.value) == 0.
         return check_obj
     except AssertionError:
-        raise CheckError('{} is non-zero'.format(check_obj._val))
+        raise CheckError('{} is non-zero'.format(check_obj.value))
 
 
 def is_not_zero(check_obj):
     check_obj.is_real()
     try:
-        assert float(check_obj._val) != 0.
+        assert float(check_obj.value) != 0.
         return check_obj
     except AssertionError:
-        raise CheckError('{} is non-zero'.format(check_obj._val))
+        raise CheckError('{} is non-zero'.format(check_obj.value))
 
 
 def is_at_least(check_obj, lower):
     check_obj.is_real()
     Check(lower).is_real()
     try:
-        assert float(check_obj._val) >= float(lower)
+        assert float(check_obj.value) >= float(lower)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is smaller than {}'.format(check_obj._val, lower))
+        raise CheckError('{} is smaller than {}'.format(check_obj.value, lower))
 
 
 def is_at_most(check_obj, upper):
     check_obj.is_real()
     Check(upper).is_real()
     try:
-        assert float(check_obj._val) <= float(upper)
+        assert float(check_obj.value) <= float(upper)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is bigger than {}'.format(check_obj._val, upper))
+        raise CheckError('{} is bigger than {}'.format(check_obj.value, upper))
 
 
 def is_between(check_obj, lower, upper):
@@ -171,7 +171,7 @@ def is_not_between(check_obj, lower, upper):
     Check(lower).is_real()
     Check(upper).is_real()
     try:
-        assert float(check_obj._val) <= lower or float(check_obj._val) >= upper
+        assert float(check_obj.value) <= lower or float(check_obj.value) >= upper
         return check_obj
     except AssertionError:
-        raise CheckError('{} is between {} and {}'.format(check_obj._val, lower, upper))
+        raise CheckError('{} is between {} and {}'.format(check_obj.value, lower, upper))

--- a/fluentcheck/assertions_check/sequences.py
+++ b/fluentcheck/assertions_check/sequences.py
@@ -3,32 +3,32 @@ from ..exceptions import CheckError
 
 def is_empty(check_obj):
     try:
-        assert len(check_obj._val) == 0
+        assert len(check_obj.value) == 0
         return check_obj
     except:
-        raise CheckError('{} is not empty'.format(check_obj._val))
+        raise CheckError('{} is not empty'.format(check_obj.value))
 
 
 def is_not_empty(check_obj):
     try:
-        assert len(check_obj._val) != 0
+        assert len(check_obj.value) != 0
         return check_obj
     except:
-        raise CheckError('{} is empty'.format(check_obj._val))
+        raise CheckError('{} is empty'.format(check_obj.value))
 
 
 def is_iterable(check_obj):
     try:
-        iter(check_obj._val)
+        iter(check_obj.value)
         return check_obj
     except TypeError:
-        raise CheckError('{} is not iterable'.format(check_obj._val))
+        raise CheckError('{} is not iterable'.format(check_obj.value))
 
 
 def is_not_iterable(check_obj):
     try:
-        iter(check_obj._val)
-        raise CheckError('{} is iterable'.format(check_obj._val))
+        iter(check_obj.value)
+        raise CheckError('{} is iterable'.format(check_obj.value))
     except TypeError:
         return check_obj
 
@@ -36,28 +36,28 @@ def is_not_iterable(check_obj):
 def is_couple(check_obj):
     check_obj.is_iterable()
     try:
-        assert len(check_obj._val) == 2
+        assert len(check_obj.value) == 2
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a sequence of 2 items'.format(check_obj._val))
+        raise CheckError('{} is not a sequence of 2 items'.format(check_obj.value))
 
 
 def is_triplet(check_obj):
     check_obj.is_iterable()
     try:
-        assert len(check_obj._val) == 3
+        assert len(check_obj.value) == 3
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a sequence of 3 items'.format(check_obj._val))
+        raise CheckError('{} is not a sequence of 3 items'.format(check_obj.value))
 
 
 def is_nuple(check_obj, dimension):
     check_obj.is_iterable()
     try:
-        assert len(check_obj._val) == dimension
+        assert len(check_obj.value) == dimension
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a sequence of {} items'.format(check_obj._val, dimension))
+        raise CheckError('{} is not a sequence of {} items'.format(check_obj.value, dimension))
 
 
 def has_dimensionality(check_obj, dimensionality):
@@ -70,27 +70,27 @@ def has_dimensionality(check_obj, dimensionality):
             return 0
         return 1 + get_dimensionality(item[0])
 
-    actual_dimensionality = get_dimensionality(check_obj._val)
+    actual_dimensionality = get_dimensionality(check_obj.value)
     if actual_dimensionality == dimensionality:
         return check_obj
     else:
         raise CheckError('{} has actual dimensionality of {}, not {}'.format(
-            check_obj._val, actual_dimensionality, dimensionality))
+            check_obj.value, actual_dimensionality, dimensionality))
 
 
 # Tuples
 def is_tuple(check_obj):
     try:
-        assert isinstance(check_obj._val, tuple)
+        assert isinstance(check_obj.value, tuple)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a tuple'.format(check_obj._val))
+        raise CheckError('{} is not a tuple'.format(check_obj.value))
 
 
 # List
 def is_list(check_obj):
     try:
-        assert isinstance(check_obj._val, list)
+        assert isinstance(check_obj.value, list)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a list'.format(check_obj._val))
+        raise CheckError('{} is not a list'.format(check_obj.value))

--- a/fluentcheck/assertions_check/strings.py
+++ b/fluentcheck/assertions_check/strings.py
@@ -7,145 +7,145 @@ from xml.etree import ElementTree
 
 def is_string(check_obj):
     try:
-        assert isinstance(check_obj._val, str)
+        assert isinstance(check_obj.value, str)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a string'.format(check_obj._val))
+        raise CheckError('{} is not a string'.format(check_obj.value))
 
 
 def is_not_string(check_obj):
     try:
-        assert not isinstance(check_obj._val, str)
+        assert not isinstance(check_obj.value, str)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is a string'.format(check_obj._val))
+        raise CheckError('{} is a string'.format(check_obj.value))
 
 
 def contains_numbers(check_obj):
     check_obj.is_string()
     try:
-        assert any(char.isdigit() for char in check_obj._val)
+        assert any(char.isdigit() for char in check_obj.value)
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain numbers'.format(check_obj._val))
+        raise CheckError('{} does not contain numbers'.format(check_obj.value))
 
 
 def not_contains_numbers(check_obj):
     check_obj.is_string()
     try:
-        assert not any(char.isdigit() for char in check_obj._val)
+        assert not any(char.isdigit() for char in check_obj.value)
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain numbers'.format(check_obj._val))
+        raise CheckError('{} does not contain numbers'.format(check_obj.value))
 
 
 def contains_numbers_only(check_obj):
     check_obj.is_string()
     try:
-        assert check_obj._val.isdigit()
+        assert check_obj.value.isdigit()
         return check_obj
     except AssertionError:
-        raise CheckError('{} also contains numbers'.format(check_obj._val))
+        raise CheckError('{} also contains numbers'.format(check_obj.value))
 
 
 def contains_chars(check_obj):
     check_obj.is_string()
     try:
-        assert bool(re.search('[a-zA-Z]', check_obj._val))
+        assert bool(re.search('[a-zA-Z]', check_obj.value))
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain chars'.format(check_obj._val))
+        raise CheckError('{} does not contain chars'.format(check_obj.value))
 
 
 def not_contains_chars(check_obj):
     check_obj.is_string()
     try:
-        assert not bool(re.search('[a-zA-Z]', check_obj._val))
+        assert not bool(re.search('[a-zA-Z]', check_obj.value))
         return check_obj
     except AssertionError:
-        raise CheckError('{} contains chars'.format(check_obj._val))
+        raise CheckError('{} contains chars'.format(check_obj.value))
 
 
 def contains_chars_only(check_obj):
     check_obj.is_string()
     try:
-        assert check_obj._val.isalpha()
+        assert check_obj.value.isalpha()
         return check_obj
     except AssertionError:
-        raise CheckError('{} also contains alphanumeric chars'.format(check_obj._val))
+        raise CheckError('{} also contains alphanumeric chars'.format(check_obj.value))
 
 
 def contains_spaces(check_obj):
     check_obj.is_string()
     try:
-        assert ' ' in check_obj._val
+        assert ' ' in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain whitespaces'.format(check_obj._val))
+        raise CheckError('{} does not contain whitespaces'.format(check_obj.value))
 
 
 def not_contains_spaces(check_obj):
     check_obj.is_string()
     try:
-        assert not ' ' in check_obj._val
+        assert not ' ' in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} contains whitespaces'.format(check_obj._val))
+        raise CheckError('{} contains whitespaces'.format(check_obj.value))
 
 
 def contains_char(check_obj, _char):
     check_obj.is_string()
     try:
-        assert _char in check_obj._val
+        assert _char in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not contain char: {}'.format(check_obj._val,
+        raise CheckError('{} does not contain char: {}'.format(check_obj.value,
                                                                _char))
 
 
 def not_contains_char(check_obj, _char):
     check_obj.is_string()
     try:
-        assert not _char in check_obj._val
+        assert not _char in check_obj.value
         return check_obj
     except AssertionError:
-        raise CheckError('{} contains char: {}'.format(check_obj._val, _char))
+        raise CheckError('{} contains char: {}'.format(check_obj.value, _char))
 
 
 def is_shorter_than(check_obj, n_chars):
     check_obj.is_string()
     try:
-        assert len(check_obj._val) < n_chars
+        assert len(check_obj.value) < n_chars
         return check_obj
     except AssertionError:
-        raise CheckError('{} is longer than {}'.format(check_obj._val, n_chars))
+        raise CheckError('{} is longer than {}'.format(check_obj.value, n_chars))
 
 
 def is_longer_than(check_obj, n_chars):
     check_obj.is_string()
     try:
-        assert len(check_obj._val) > n_chars
+        assert len(check_obj.value) > n_chars
         return check_obj
     except AssertionError:
-        raise CheckError('{} is shorter than {}'.format(check_obj._val, n_chars))
+        raise CheckError('{} is shorter than {}'.format(check_obj.value, n_chars))
 
 
 def has_length(check_obj, n_items):
     check_obj.is_string()
     try:
-        assert len(check_obj._val) == n_items
+        assert len(check_obj.value) == n_items
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not long {}'.format(check_obj._val, n_items))
+        raise CheckError('{} is not long {}'.format(check_obj.value, n_items))
 
 
 def has_not_length(check_obj, n_items):
     check_obj.is_string()
     try:
-        assert len(check_obj._val) != n_items
+        assert len(check_obj.value) != n_items
         return check_obj
     except AssertionError:
-        raise CheckError('{} is long {}'.format(check_obj._val, n_items))
+        raise CheckError('{} is long {}'.format(check_obj.value, n_items))
 
 
 def is_lowercase(check_obj):
@@ -153,10 +153,10 @@ def is_lowercase(check_obj):
     if check_obj.is_empty():
         return check_obj
     try:
-        assert all([c.islower() for c in check_obj._val])
+        assert all([c.islower() for c in check_obj.value])
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not lowercase'.format(check_obj._val))
+        raise CheckError('{} is not lowercase'.format(check_obj.value))
 
 
 def is_not_lowercase(check_obj):
@@ -164,10 +164,10 @@ def is_not_lowercase(check_obj):
     if check_obj.is_empty():
         return check_obj
     try:
-        assert any([not c.islower() for c in check_obj._val])
+        assert any([not c.islower() for c in check_obj.value])
         return check_obj
     except AssertionError:
-        raise CheckError('{} is lowercase'.format(check_obj._val))
+        raise CheckError('{} is lowercase'.format(check_obj.value))
 
 
 def is_uppercase(check_obj):
@@ -175,10 +175,10 @@ def is_uppercase(check_obj):
     if check_obj.is_empty():
         return check_obj
     try:
-        assert all([c.isupper() for c in check_obj._val])
+        assert all([c.isupper() for c in check_obj.value])
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not uppercase'.format(check_obj._val))
+        raise CheckError('{} is not uppercase'.format(check_obj.value))
 
 
 def is_not_uppercase(check_obj):
@@ -186,10 +186,10 @@ def is_not_uppercase(check_obj):
     if check_obj.is_empty():
         return check_obj
     try:
-        assert any([not c.isupper() for c in check_obj._val])
+        assert any([not c.isupper() for c in check_obj.value])
         return check_obj
     except AssertionError:
-        raise CheckError('{} is uppercase'.format(check_obj._val))
+        raise CheckError('{} is uppercase'.format(check_obj.value))
 
 
 def is_snakecase(check_obj):
@@ -197,12 +197,12 @@ def is_snakecase(check_obj):
     if check_obj.is_empty():
         return check_obj
     try:
-        tokens = check_obj._val.split('_')
+        tokens = check_obj.value.split('_')
         assert len(tokens) > 1
         assert not any([' ' in t for t in tokens])
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not snakecase'.format(check_obj._val))
+        raise CheckError('{} is not snakecase'.format(check_obj.value))
 
 
 def is_not_snakecase(check_obj):
@@ -211,7 +211,7 @@ def is_not_snakecase(check_obj):
         return check_obj
     try:
         check_obj.is_snakecase()
-        raise CheckError('{} is snakecase'.format(check_obj._val))
+        raise CheckError('{} is snakecase'.format(check_obj.value))
     except AssertionError:
         return check_obj
 
@@ -219,35 +219,35 @@ def is_not_snakecase(check_obj):
 def is_camelcase(check_obj):
     check_obj.is_string()
     try:
-        assert (check_obj._val != check_obj._val.lower() and check_obj._val != check_obj._val.upper())
+        assert (check_obj.value != check_obj.value.lower() and check_obj.value != check_obj.value.upper())
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not camelcase'.format(check_obj._val))
+        raise CheckError('{} is not camelcase'.format(check_obj.value))
 
 
 def is_not_camelcase(check_obj):
     check_obj.is_string()
     try:
-        assert not (check_obj._val != check_obj._val.lower() and check_obj._val != check_obj._val.upper())
+        assert not (check_obj.value != check_obj.value.lower() and check_obj.value != check_obj.value.upper())
         return check_obj
     except AssertionError:
-        raise CheckError('{} is camelcase'.format(check_obj._val))
+        raise CheckError('{} is camelcase'.format(check_obj.value))
 
 
 def is_json(check_obj):
     check_obj.is_string()
     try:
-        json.loads(check_obj._val)
+        json.loads(check_obj.value)
         return check_obj
     except ValueError:
-        raise CheckError('{} is not valid JSON'.format(check_obj._val))
+        raise CheckError('{} is not valid JSON'.format(check_obj.value))
 
 
 def is_not_json(check_obj):
     check_obj.is_string()
     try:
-        json.loads(check_obj._val)
-        raise CheckError('{} is valid JSON'.format(check_obj._val))
+        json.loads(check_obj.value)
+        raise CheckError('{} is valid JSON'.format(check_obj.value))
     except ValueError:
         return check_obj
 
@@ -255,9 +255,9 @@ def is_not_json(check_obj):
 def is_yaml(check_obj):
     check_obj.is_string()
     try:
-        yaml.load(check_obj._val)
+        yaml.load(check_obj.value)
     except Exception:
-        raise CheckError('{} is not valid YAML'.format(check_obj._val))
+        raise CheckError('{} is not valid YAML'.format(check_obj.value))
     else:
         return check_obj
 
@@ -265,19 +265,19 @@ def is_yaml(check_obj):
 def is_not_yaml(check_obj):
     check_obj.is_string()
     try:
-        yaml.load(check_obj._val)
+        yaml.load(check_obj.value)
     except Exception:
         return check_obj
     else:
-        raise CheckError('{} is valid YAML'.format(check_obj._val))
+        raise CheckError('{} is valid YAML'.format(check_obj.value))
 
 
 def is_xml(check_obj):
     check_obj.is_string()
     try:
-        ElementTree.fromstring(check_obj._val)
+        ElementTree.fromstring(check_obj.value)
     except Exception:
-        raise CheckError('{} is not valid XML'.format(check_obj._val))
+        raise CheckError('{} is not valid XML'.format(check_obj.value))
     else:
         return check_obj
 
@@ -285,21 +285,21 @@ def is_xml(check_obj):
 def is_not_xml(check_obj):
     check_obj.is_string()
     try:
-        ElementTree.fromstring(check_obj._val)
+        ElementTree.fromstring(check_obj.value)
     except Exception:
         return check_obj
     else:
-        raise CheckError('{} is valid XML'.format(check_obj._val))
+        raise CheckError('{} is valid XML'.format(check_obj.value))
 
 
 def matches(check_obj, regex):
     check_obj.is_string()
     try:
         pattern = re.compile(regex)
-        assert pattern.match(check_obj._val) is not None
+        assert pattern.match(check_obj.value) is not None
         return check_obj
     except AssertionError:
-        raise CheckError('{} does not match pattern: {}'.format(check_obj._val,
+        raise CheckError('{} does not match pattern: {}'.format(check_obj.value,
                                                                 regex))
 
 
@@ -307,7 +307,7 @@ def not_matches(check_obj, regex):
     check_obj.is_string()
     try:
         pattern = re.compile(regex)
-        assert not pattern.match(check_obj._val) is not None
+        assert not pattern.match(check_obj.value) is not None
         return check_obj
     except AssertionError:
-        raise CheckError('{} matches pattern: {}'.format(check_obj._val, regex))
+        raise CheckError('{} matches pattern: {}'.format(check_obj.value, regex))

--- a/fluentcheck/assertions_check/types.py
+++ b/fluentcheck/assertions_check/types.py
@@ -4,63 +4,63 @@ from ..exceptions import CheckError
 
 def is_subtype_of(check_obj, _type):
     try:
-        assert issubclass(check_obj._val.__class__, _type)
+        assert issubclass(check_obj.value.__class__, _type)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not subtype of {}'.format(check_obj._val, _type))
+        raise CheckError('{} is not subtype of {}'.format(check_obj.value, _type))
 
 
 def is_not_subtype_of(check_obj, _type):
     try:
-        assert not issubclass(check_obj._val.__class__, _type)
+        assert not issubclass(check_obj.value.__class__, _type)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is subtype of {}'.format(check_obj._val, _type))
+        raise CheckError('{} is subtype of {}'.format(check_obj.value, _type))
 
 
 def is_of_type(check_obj, _type):
     try:
-        assert isinstance(check_obj._val, _type)
+        assert isinstance(check_obj.value, _type)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not of type {}'.format(check_obj._val, _type))
+        raise CheckError('{} is not of type {}'.format(check_obj.value, _type))
 
 
 def is_not_of_type(check_obj, _type):
     try:
-        assert not isinstance(check_obj._val, _type)
+        assert not isinstance(check_obj.value, _type)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is of type {}'.format(check_obj._val, _type))
+        raise CheckError('{} is of type {}'.format(check_obj.value, _type))
 
 
 def is_module(check_obj):
     try:
-        assert isinstance(check_obj._val, t.ModuleType)
+        assert isinstance(check_obj.value, t.ModuleType)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not a module'.format(check_obj._val))
+        raise CheckError('{} is not a module'.format(check_obj.value))
 
 
 def is_not_module(check_obj):
     try:
-        assert not isinstance(check_obj._val, t.ModuleType)
+        assert not isinstance(check_obj.value, t.ModuleType)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is a module'.format(check_obj._val))
+        raise CheckError('{} is a module'.format(check_obj.value))
 
 
 def is_runnable(check_obj):
     try:
-        assert isinstance(check_obj._val, t.FunctionType)
+        assert isinstance(check_obj.value, t.FunctionType)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is not runnable'.format(check_obj._val))
+        raise CheckError('{} is not runnable'.format(check_obj.value))
 
 
 def is_not_runnable(check_obj):
     try:
-        assert not isinstance(check_obj._val, t.FunctionType)
+        assert not isinstance(check_obj.value, t.FunctionType)
         return check_obj
     except AssertionError:
-        raise CheckError('{} is runnable'.format(check_obj._val))
+        raise CheckError('{} is runnable'.format(check_obj.value))

--- a/fluentcheck/assertions_check/uuids.py
+++ b/fluentcheck/assertions_check/uuids.py
@@ -1,6 +1,6 @@
-from ..classes import Check
-from ..exceptions import CheckError
 from uuid import UUID
+
+from ..exceptions import CheckError
 
 
 def is_uuid1(check_obj):
@@ -8,17 +8,17 @@ def is_uuid1(check_obj):
         assert (UUID(check_obj.value).version == 1)
         return check_obj
     except (AssertionError, AttributeError, ValueError) as e:
-        raise CheckError('{} is not a valid uuid1 exception: {}'.format(check_obj._val, e))
+        raise CheckError('{} is not a valid uuid1 exception: {}'.format(check_obj.value, e))
 
 
 def is_not_uuid1(check_obj):
     try:
-        assert UUID(check_obj._val).version != 1
+        assert UUID(check_obj.value).version != 1
         return check_obj
-    except ValueError:  # check_obj._val is not a UUID at all
-        raise CheckError('{} is not a valid uuid'.format(check_obj._val))
-    except:  # check_obj._val is a UUID, but is indeed v1
-        raise CheckError('{} is a uuid1'.format(check_obj._val))
+    except ValueError:  # check_obj.value is not a UUID at all
+        raise CheckError('{} is not a valid uuid'.format(check_obj.value))
+    except:  # check_obj.value is a UUID, but is indeed v1
+        raise CheckError('{} is a uuid1'.format(check_obj.value))
 
 
 def is_uuid4(check_obj):
@@ -26,14 +26,14 @@ def is_uuid4(check_obj):
         assert (UUID(check_obj.value).version == 4)
         return check_obj
     except (AssertionError, AttributeError, ValueError):
-        raise CheckError('{} is not a valid uuid4'.format(check_obj._val))
+        raise CheckError('{} is not a valid uuid4'.format(check_obj.value))
 
 
 def is_not_uuid4(check_obj):
     try:
-        assert UUID(check_obj._val).version != 4
+        assert UUID(check_obj.value).version != 4
         return check_obj
-    except ValueError:  # check_obj._val is not a UUID at all
-        raise CheckError('{} is not a valid uuid'.format(check_obj._val))
-    except:  # check_obj._val is a UUID, but is indeed v4
-        raise CheckError('{} is a uuid4'.format(check_obj._val))
+    except ValueError:  # check_obj.value is not a UUID at all
+        raise CheckError('{} is not a valid uuid'.format(check_obj.value))
+    except:  # check_obj.value is a UUID, but is indeed v4
+        raise CheckError('{} is a uuid4'.format(check_obj.value))


### PR DESCRIPTION
Here's an example of the warning before:

<img width="761" alt="Screen Shot 2020-04-05 at 9 39 18 AM" src="https://user-images.githubusercontent.com/2035561/78504419-fb2edd00-7721-11ea-9e45-277bd9f1d0c1.png">
