### PR TITLE
Raise better error messages

### DIFF
--- a/fluentcheck/assertions_check/booleans.py
+++ b/fluentcheck/assertions_check/booleans.py
@@ -5,32 +5,32 @@ def is_boolean(check_obj):
     try:
         assert isinstance(check_obj._val, bool)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not boolean'.format(check_obj._val))
+    except AssertionError as ae:
+        raise CheckError('{} is not boolean'.format(check_obj._val)) from ae
 
 
 def is_not_boolean(check_obj):
     try:
         assert not isinstance(check_obj._val, bool)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is boolean'.format(check_obj._val))
+    except AssertionError as ae:
+        raise CheckError('{} is boolean'.format(check_obj._val)) from ae
 
 
 def is_truthy(check_obj):
     try:
         assert check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is falsy'.format(check_obj._val))
+    except AssertionError as ae:
+        raise CheckError('{} is falsy'.format(check_obj._val)) from ae
 
 
 def is_falsy(check_obj):
     try:
         assert not check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is truthy'.format(check_obj._val))
+    except AssertionError as ae:
+        raise CheckError('{} is truthy'.format(check_obj._val)) from ae
 
 
 def is_not_truthy(check_obj):
@@ -61,15 +61,15 @@ def has_same_truth_of(check_obj, value):
     try:
         assert bool(check_obj._val) == bool(value)
         return check_obj
-    except AssertionError:
+    except AssertionError as ae:
         raise CheckError('{} has a different truth of {}'.format(check_obj._val,
-                                                                 value))
+                                                                 value)) from ae
 
 
 def has_opposite_truth_of(check_obj, value):
     try:
         assert bool(check_obj._val) != bool(value)
         return check_obj
-    except AssertionError:
+    except AssertionError as ae:
         raise CheckError('{} has the same truth of {}'.format(check_obj._val,
-                                                              value))
+                                                              value)) from ae

--- a/fluentcheck/assertions_check/collections.py
+++ b/fluentcheck/assertions_check/collections.py
@@ -5,16 +5,16 @@ def is_set(check_obj):
     try:
         assert isinstance(check_obj._val, set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a set'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a set'.format(check_obj._val)) from e
 
 
 def is_not_set(check_obj):
     try:
         assert not isinstance(check_obj._val, set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is a set'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is a set'.format(check_obj._val)) from e
 
 
 def is_subset_of(check_obj, _set):
@@ -22,8 +22,8 @@ def is_subset_of(check_obj, _set):
     try:
         assert check_obj._val.issubset(_set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not subset of {}'.format(check_obj._val, _set))
+    except AssertionError as e:
+        raise CheckError('{} is not subset of {}'.format(check_obj._val, _set)) from e
 
 
 def is_not_subset_of(check_obj, _set):
@@ -31,8 +31,8 @@ def is_not_subset_of(check_obj, _set):
     try:
         assert not check_obj._val.issubset(_set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is subset of {}'.format(check_obj._val, _set))
+    except AssertionError as e:
+        raise CheckError('{} is subset of {}'.format(check_obj._val, _set)) from e
 
 
 def is_superset_of(check_obj, _set):
@@ -40,8 +40,8 @@ def is_superset_of(check_obj, _set):
     try:
         assert check_obj._val.issuperset(_set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not superset of {}'.format(check_obj._val, _set))
+    except AssertionError as e:
+        raise CheckError('{} is not superset of {}'.format(check_obj._val, _set)) from e
 
 
 def is_not_superset_of(check_obj, _set):
@@ -49,8 +49,8 @@ def is_not_superset_of(check_obj, _set):
     try:
         assert not check_obj._val.issuperset(_set)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is superset of {}'.format(check_obj._val, _set))
+    except AssertionError as e:
+        raise CheckError('{} is superset of {}'.format(check_obj._val, _set)) from e
 
 
 def intersects(check_obj, _set):
@@ -58,8 +58,8 @@ def intersects(check_obj, _set):
     try:
         assert len(check_obj._val.intersection(_set)) != 0
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not intersect {}'.format(check_obj._val, _set))
+    except AssertionError as e:
+        raise CheckError('{} does not intersect {}'.format(check_obj._val, _set)) from e
 
 
 def not_intersects(check_obj, _set):
@@ -67,6 +67,5 @@ def not_intersects(check_obj, _set):
     try:
         assert len(check_obj._val.intersection(_set)) == 0
         return check_obj
-    except AssertionError:
-        raise CheckError('{} intersects {}'.format(check_obj._val, _set))
-
+    except AssertionError as e:
+        raise CheckError('{} intersects {}'.format(check_obj._val, _set)) from e

--- a/fluentcheck/assertions_check/dicts.py
+++ b/fluentcheck/assertions_check/dicts.py
@@ -5,16 +5,16 @@ def is_dict(check_obj):
     try:
         assert isinstance(check_obj._val, dict)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a dict'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a dict'.format(check_obj._val)) from e
 
 
 def is_not_dict(check_obj):
     try:
         assert not isinstance(check_obj._val, dict)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is a dict'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is a dict'.format(check_obj._val)) from e
 
 
 def has_keys(check_obj, *args):
@@ -25,9 +25,9 @@ def has_keys(check_obj, *args):
             cur_key = key
             assert key in check_obj._val
         return check_obj
-    except AssertionError:
+    except AssertionError as e:
         raise CheckError('{} does not contain key: {}'.format(check_obj._val,
-                                                              cur_key))
+                                                              cur_key)) from e
 
 
 def has_not_keys(check_obj, *args):
@@ -38,5 +38,5 @@ def has_not_keys(check_obj, *args):
             cur_key = key
             assert not key in check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does contains key: {}'.format(check_obj._val, cur_key))
+    except AssertionError as e:
+        raise CheckError('{} does contains key: {}'.format(check_obj._val, cur_key)) from e

--- a/fluentcheck/assertions_check/geo.py
+++ b/fluentcheck/assertions_check/geo.py
@@ -7,8 +7,8 @@ def is_latitude(check_obj):
     try:
         check_obj.is_between(-90.0, 90.0)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a valid latitude'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a valid latitude'.format(check_obj._val)) from e
 
 
 def is_longitude(check_obj):
@@ -16,15 +16,15 @@ def is_longitude(check_obj):
     try:
         check_obj.is_between(-180.0, 180.0)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a valid longitude'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a valid longitude'.format(check_obj._val)) from e
 
 
 def is_azimuth(check_obj):
     try:
         check_obj.is_number().is_positive()
     except:
-        raise CheckError('{} is not a valid azimuth'.format(check_obj._val))
+        raise CheckError('{} is not a valid azimuth'.format(check_obj._val)) from e
 
 
 def is_geopoint(check_obj):
@@ -34,5 +34,5 @@ def is_geopoint(check_obj):
         first.is_long()
         second = Check(check_obj._val[1])
         second.is_latitude()
-    except AssertionError:
-        raise CheckError('{} is not a valid geographic point'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a valid geographic point'.format(check_obj._val)) from e

--- a/fluentcheck/assertions_check/geo.py
+++ b/fluentcheck/assertions_check/geo.py
@@ -23,7 +23,8 @@ def is_longitude(check_obj):
 def is_azimuth(check_obj):
     try:
         check_obj.is_number().is_positive()
-    except:
+        return check_obj
+    except Exception as e:
         raise CheckError('{} is not a valid azimuth'.format(check_obj._val)) from e
 
 
@@ -31,8 +32,9 @@ def is_geopoint(check_obj):
     check_obj.is_couple()
     try:
         first = Check(check_obj._val[0])
-        first.is_long()
+        first.is_longitude()
         second = Check(check_obj._val[1])
         second.is_latitude()
+        return check_obj
     except AssertionError as e:
         raise CheckError('{} is not a valid geographic point'.format(check_obj._val)) from e

--- a/fluentcheck/assertions_check/numbers.py
+++ b/fluentcheck/assertions_check/numbers.py
@@ -6,48 +6,48 @@ def is_number(check_obj):
     try:
         assert isinstance(check_obj._val, check_obj.NUMERIC_TYPES)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a number'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a number'.format(check_obj._val)) from e
 
 
 def is_not_number(check_obj):
     try:
         assert not isinstance(check_obj._val, check_obj.NUMERIC_TYPES)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is a number'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is a number'.format(check_obj._val)) from e
 
 
 def is_integer(check_obj):
     try:
         assert isinstance(check_obj._val, int)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not integer'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not integer'.format(check_obj._val)) from e
 
 
 def is_not_integer(check_obj):
     try:
         assert not isinstance(check_obj._val, int)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is integer'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is integer'.format(check_obj._val)) from e
 
 
 def is_float(check_obj):
     try:
         assert isinstance(check_obj._val, float)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not float'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not float'.format(check_obj._val)) from e
 
 
 def is_not_float(check_obj):
     try:
         assert not isinstance(check_obj._val, float)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is float'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is float'.format(check_obj._val)) from e
 
 
 def is_real(check_obj):
@@ -55,8 +55,8 @@ def is_real(check_obj):
     try:
         assert not isinstance(check_obj._val, complex)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not real'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not real'.format(check_obj._val)) from e
 
 
 def is_not_real(check_obj):
@@ -64,24 +64,24 @@ def is_not_real(check_obj):
     try:
         assert isinstance(check_obj._val, complex)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is real'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is real'.format(check_obj._val)) from e
 
 
 def is_complex(check_obj):
     try:
         assert isinstance(check_obj._val, complex)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not complex'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not complex'.format(check_obj._val)) from e
 
 
 def is_not_complex(check_obj):
     try:
         assert not isinstance(check_obj._val, complex)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is complex'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is complex'.format(check_obj._val)) from e
 
 
 def is_positive(check_obj):
@@ -89,8 +89,8 @@ def is_positive(check_obj):
     try:
         assert float(check_obj._val) > 0.
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is zero or negative'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is zero or negative'.format(check_obj._val)) from e
 
 
 def is_not_positive(check_obj):
@@ -98,8 +98,8 @@ def is_not_positive(check_obj):
     try:
         assert float(check_obj._val) <= 0
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is positive'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is positive'.format(check_obj._val)) from e
 
 
 def is_negative(check_obj):
@@ -107,8 +107,8 @@ def is_negative(check_obj):
     try:
         assert float(check_obj._val) < 0.
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is zero or positive'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is zero or positive'.format(check_obj._val)) from e
 
 
 def is_not_negative(check_obj):
@@ -116,8 +116,8 @@ def is_not_negative(check_obj):
     try:
         assert float(check_obj._val) >= 0
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is negative'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is negative'.format(check_obj._val)) from e
 
 
 def is_zero(check_obj):
@@ -125,8 +125,8 @@ def is_zero(check_obj):
     try:
         assert float(check_obj._val) == 0.
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is non-zero'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is non-zero'.format(check_obj._val)) from e
 
 
 def is_not_zero(check_obj):
@@ -134,8 +134,8 @@ def is_not_zero(check_obj):
     try:
         assert float(check_obj._val) != 0.
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is non-zero'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is non-zero'.format(check_obj._val)) from e
 
 
 def is_at_least(check_obj, lower):
@@ -144,8 +144,8 @@ def is_at_least(check_obj, lower):
     try:
         assert float(check_obj._val) >= float(lower)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is smaller than {}'.format(check_obj._val, lower))
+    except AssertionError as e:
+        raise CheckError('{} is smaller than {}'.format(check_obj._val, lower)) from e
 
 
 def is_at_most(check_obj, upper):
@@ -154,8 +154,8 @@ def is_at_most(check_obj, upper):
     try:
         assert float(check_obj._val) <= float(upper)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is bigger than {}'.format(check_obj._val, upper))
+    except AssertionError as e:
+        raise CheckError('{} is bigger than {}'.format(check_obj._val, upper)) from e
 
 
 def is_between(check_obj, lower, upper):
@@ -173,5 +173,5 @@ def is_not_between(check_obj, lower, upper):
     try:
         assert float(check_obj._val) <= lower or float(check_obj._val) >= upper
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is between {} and {}'.format(check_obj._val, lower, upper))
+    except AssertionError as e:
+        raise CheckError('{} is between {} and {}'.format(check_obj._val, lower, upper)) from e

--- a/fluentcheck/assertions_check/sequences.py
+++ b/fluentcheck/assertions_check/sequences.py
@@ -5,24 +5,24 @@ def is_empty(check_obj):
     try:
         assert len(check_obj._val) == 0
         return check_obj
-    except:
-        raise CheckError('{} is not empty'.format(check_obj._val))
+    except Exception as e:
+        raise CheckError('{} is not empty'.format(check_obj._val)) from e
 
 
 def is_not_empty(check_obj):
     try:
         assert len(check_obj._val) != 0
         return check_obj
-    except:
-        raise CheckError('{} is empty'.format(check_obj._val))
+    except Exception as e:
+        raise CheckError('{} is empty'.format(check_obj._val)) from e
 
 
 def is_iterable(check_obj):
     try:
         iter(check_obj._val)
         return check_obj
-    except TypeError:
-        raise CheckError('{} is not iterable'.format(check_obj._val))
+    except TypeError as e:
+        raise CheckError('{} is not iterable'.format(check_obj._val)) from e
 
 
 def is_not_iterable(check_obj):
@@ -38,8 +38,8 @@ def is_couple(check_obj):
     try:
         assert len(check_obj._val) == 2
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a sequence of 2 items'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a sequence of 2 items'.format(check_obj._val)) from e
 
 
 def is_triplet(check_obj):
@@ -47,8 +47,8 @@ def is_triplet(check_obj):
     try:
         assert len(check_obj._val) == 3
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a sequence of 3 items'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a sequence of 3 items'.format(check_obj._val)) from e
 
 
 def is_nuple(check_obj, dimension):
@@ -56,8 +56,8 @@ def is_nuple(check_obj, dimension):
     try:
         assert len(check_obj._val) == dimension
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a sequence of {} items'.format(check_obj._val, dimension))
+    except AssertionError as e:
+        raise CheckError('{} is not a sequence of {} items'.format(check_obj._val, dimension)) from e
 
 
 def has_dimensionality(check_obj, dimensionality):
@@ -83,8 +83,8 @@ def is_tuple(check_obj):
     try:
         assert isinstance(check_obj._val, tuple)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a tuple'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a tuple'.format(check_obj._val)) from e
 
 
 # List
@@ -92,5 +92,5 @@ def is_list(check_obj):
     try:
         assert isinstance(check_obj._val, list)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a list'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a list'.format(check_obj._val)) from e

--- a/fluentcheck/assertions_check/strings.py
+++ b/fluentcheck/assertions_check/strings.py
@@ -11,16 +11,16 @@ def is_string(check_obj):
     try:
         assert isinstance(check_obj._val, str)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a string'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a string'.format(check_obj._val)) from e
 
 
 def is_not_string(check_obj):
     try:
         assert not isinstance(check_obj._val, str)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is a string'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is a string'.format(check_obj._val)) from e
 
 
 def contains_numbers(check_obj):
@@ -28,8 +28,8 @@ def contains_numbers(check_obj):
     try:
         assert any(char.isdigit() for char in check_obj._val)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not contain numbers'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} does not contain numbers'.format(check_obj._val)) from e
 
 
 def not_contains_numbers(check_obj):
@@ -37,8 +37,8 @@ def not_contains_numbers(check_obj):
     try:
         assert not any(char.isdigit() for char in check_obj._val)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not contain numbers'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} does not contain numbers'.format(check_obj._val)) from e
 
 
 def contains_numbers_only(check_obj):
@@ -46,8 +46,8 @@ def contains_numbers_only(check_obj):
     try:
         assert check_obj._val.isdigit()
         return check_obj
-    except AssertionError:
-        raise CheckError('{} also contains numbers'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} also contains numbers'.format(check_obj._val)) from e
 
 
 def contains_chars(check_obj):
@@ -55,8 +55,8 @@ def contains_chars(check_obj):
     try:
         assert bool(re.search('[a-zA-Z]', check_obj._val))
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not contain chars'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} does not contain chars'.format(check_obj._val)) from e
 
 
 def not_contains_chars(check_obj):
@@ -64,8 +64,8 @@ def not_contains_chars(check_obj):
     try:
         assert not bool(re.search('[a-zA-Z]', check_obj._val))
         return check_obj
-    except AssertionError:
-        raise CheckError('{} contains chars'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} contains chars'.format(check_obj._val)) from e
 
 
 def contains_chars_only(check_obj):
@@ -73,8 +73,8 @@ def contains_chars_only(check_obj):
     try:
         assert check_obj._val.isalpha()
         return check_obj
-    except AssertionError:
-        raise CheckError('{} also contains alphanumeric chars'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} also contains alphanumeric chars'.format(check_obj._val)) from e
 
 
 def contains_spaces(check_obj):
@@ -82,8 +82,8 @@ def contains_spaces(check_obj):
     try:
         assert ' ' in check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not contain whitespaces'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} does not contain whitespaces'.format(check_obj._val)) from e
 
 
 def not_contains_spaces(check_obj):
@@ -91,8 +91,8 @@ def not_contains_spaces(check_obj):
     try:
         assert not ' ' in check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} contains whitespaces'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} contains whitespaces'.format(check_obj._val)) from e
 
 
 def contains_char(check_obj, _char):
@@ -100,9 +100,9 @@ def contains_char(check_obj, _char):
     try:
         assert _char in check_obj._val
         return check_obj
-    except AssertionError:
+    except AssertionError as e:
         raise CheckError('{} does not contain char: {}'.format(check_obj._val,
-                                                               _char))
+                                                               _char)) from e
 
 
 def not_contains_char(check_obj, _char):
@@ -110,8 +110,8 @@ def not_contains_char(check_obj, _char):
     try:
         assert not _char in check_obj._val
         return check_obj
-    except AssertionError:
-        raise CheckError('{} contains char: {}'.format(check_obj._val, _char))
+    except AssertionError as e:
+        raise CheckError('{} contains char: {}'.format(check_obj._val, _char)) from e
 
 
 def is_shorter_than(check_obj, n_chars):
@@ -119,8 +119,8 @@ def is_shorter_than(check_obj, n_chars):
     try:
         assert len(check_obj._val) < n_chars
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is longer than {}'.format(check_obj._val, n_chars))
+    except AssertionError as e:
+        raise CheckError('{} is longer than {}'.format(check_obj._val, n_chars)) from e
 
 
 def is_longer_than(check_obj, n_chars):
@@ -128,8 +128,8 @@ def is_longer_than(check_obj, n_chars):
     try:
         assert len(check_obj._val) > n_chars
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is shorter than {}'.format(check_obj._val, n_chars))
+    except AssertionError as e:
+        raise CheckError('{} is shorter than {}'.format(check_obj._val, n_chars)) from e
 
 
 def has_length(check_obj, n_items):
@@ -137,8 +137,8 @@ def has_length(check_obj, n_items):
     try:
         assert len(check_obj._val) == n_items
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not long {}'.format(check_obj._val, n_items))
+    except AssertionError as e:
+        raise CheckError('{} is not long {}'.format(check_obj._val, n_items)) from e
 
 
 def has_not_length(check_obj, n_items):
@@ -146,8 +146,8 @@ def has_not_length(check_obj, n_items):
     try:
         assert len(check_obj._val) != n_items
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is long {}'.format(check_obj._val, n_items))
+    except AssertionError as e:
+        raise CheckError('{} is long {}'.format(check_obj._val, n_items)) from e
 
 
 def is_lowercase(check_obj):
@@ -157,8 +157,8 @@ def is_lowercase(check_obj):
     try:
         assert all([c.islower() for c in check_obj._val])
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not lowercase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not lowercase'.format(check_obj._val)) from e
 
 
 def is_not_lowercase(check_obj):
@@ -168,8 +168,8 @@ def is_not_lowercase(check_obj):
     try:
         assert any([not c.islower() for c in check_obj._val])
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is lowercase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is lowercase'.format(check_obj._val)) from e
 
 
 def is_uppercase(check_obj):
@@ -179,8 +179,8 @@ def is_uppercase(check_obj):
     try:
         assert all([c.isupper() for c in check_obj._val])
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not uppercase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not uppercase'.format(check_obj._val)) from e
 
 
 def is_not_uppercase(check_obj):
@@ -190,8 +190,8 @@ def is_not_uppercase(check_obj):
     try:
         assert any([not c.isupper() for c in check_obj._val])
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is uppercase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is uppercase'.format(check_obj._val)) from e
 
 
 def is_snakecase(check_obj):
@@ -203,8 +203,8 @@ def is_snakecase(check_obj):
         assert len(tokens) > 1
         assert not any([' ' in t for t in tokens])
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not snakecase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not snakecase'.format(check_obj._val)) from e
 
 
 def is_not_snakecase(check_obj):
@@ -223,8 +223,8 @@ def is_camelcase(check_obj):
     try:
         assert (check_obj._val != check_obj._val.lower() and check_obj._val != check_obj._val.upper())
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not camelcase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not camelcase'.format(check_obj._val)) from e
 
 
 def is_not_camelcase(check_obj):
@@ -232,8 +232,8 @@ def is_not_camelcase(check_obj):
     try:
         assert not (check_obj._val != check_obj._val.lower() and check_obj._val != check_obj._val.upper())
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is camelcase'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is camelcase'.format(check_obj._val)) from e
 
 
 def is_json(check_obj):
@@ -258,8 +258,8 @@ def is_yaml(check_obj):
     check_obj.is_string()
     try:
         yaml.safe_load(check_obj._val)
-    except Exception:
-        raise CheckError('{} is not valid YAML'.format(check_obj._val))
+    except Exception as e:
+        raise CheckError('{} is not valid YAML'.format(check_obj._val)) from e
     else:
         return check_obj
 
@@ -278,8 +278,8 @@ def is_xml(check_obj):
     check_obj.is_string()
     try:
         ElementTree.fromstring(check_obj._val)
-    except Exception:
-        raise CheckError('{} is not valid XML'.format(check_obj._val))
+    except Exception as e:
+        raise CheckError('{} is not valid XML'.format(check_obj._val)) from e
     else:
         return check_obj
 
@@ -300,8 +300,8 @@ def matches(check_obj, regex):
         pattern = re.compile(regex)
         assert pattern.match(check_obj._val) is not None
         return check_obj
-    except AssertionError:
-        raise CheckError('{} does not match pattern: {}'.format(check_obj._val, regex))
+    except AssertionError as e:
+        raise CheckError('{} does not match pattern: {}'.format(check_obj._val, regex)) from e
 
 
 def not_matches(check_obj, regex):
@@ -310,5 +310,5 @@ def not_matches(check_obj, regex):
         pattern = re.compile(regex)
         assert not pattern.match(check_obj._val) is not None
         return check_obj
-    except AssertionError:
-        raise CheckError('{} matches pattern: {}'.format(check_obj._val, regex))
+    except AssertionError as e:
+        raise CheckError('{} matches pattern: {}'.format(check_obj._val, regex)) from e

--- a/fluentcheck/assertions_check/types.py
+++ b/fluentcheck/assertions_check/types.py
@@ -6,7 +6,7 @@ def is_subtype_of(check_obj, _type):
     try:
         assert issubclass(check_obj._val.__class__, _type)
         return check_obj
-    except AssertionError:
+    except AssertionError as e:
         raise CheckError('{} is not subtype of {}'.format(check_obj._val, _type))
 
 
@@ -14,53 +14,53 @@ def is_not_subtype_of(check_obj, _type):
     try:
         assert not issubclass(check_obj._val.__class__, _type)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is subtype of {}'.format(check_obj._val, _type))
+    except AssertionError as e:
+        raise CheckError('{} is subtype of {}'.format(check_obj._val, _type)) from e
 
 
 def is_of_type(check_obj, _type):
     try:
         assert isinstance(check_obj._val, _type)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not of type {}'.format(check_obj._val, _type))
+    except AssertionError as e:
+        raise CheckError('{} is not of type {}'.format(check_obj._val, _type)) from e
 
 
 def is_not_of_type(check_obj, _type):
     try:
         assert not isinstance(check_obj._val, _type)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is of type {}'.format(check_obj._val, _type))
+    except AssertionError as e:
+        raise CheckError('{} is of type {}'.format(check_obj._val, _type)) from e
 
 
 def is_module(check_obj):
     try:
         assert isinstance(check_obj._val, t.ModuleType)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not a module'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not a module'.format(check_obj._val)) from e
 
 
 def is_not_module(check_obj):
     try:
         assert not isinstance(check_obj._val, t.ModuleType)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is a module'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is a module'.format(check_obj._val)) from e
 
 
 def is_runnable(check_obj):
     try:
         assert isinstance(check_obj._val, t.FunctionType)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is not runnable'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is not runnable'.format(check_obj._val)) from e
 
 
 def is_not_runnable(check_obj):
     try:
         assert not isinstance(check_obj._val, t.FunctionType)
         return check_obj
-    except AssertionError:
-        raise CheckError('{} is runnable'.format(check_obj._val))
+    except AssertionError as e:
+        raise CheckError('{} is runnable'.format(check_obj._val)) from e

--- a/fluentcheck/assertions_check/uuids.py
+++ b/fluentcheck/assertions_check/uuids.py
@@ -1,6 +1,6 @@
-from ..classes import Check
-from ..exceptions import CheckError
 from uuid import UUID
+
+from ..exceptions import CheckError
 
 
 def is_uuid1(check_obj):
@@ -8,32 +8,32 @@ def is_uuid1(check_obj):
         assert (UUID(check_obj.value).version == 1)
         return check_obj
     except (AssertionError, AttributeError, ValueError) as e:
-        raise CheckError('{} is not a valid uuid1 exception: {}'.format(check_obj._val, e))
+        raise CheckError('{} is not a valid uuid1 exception: {}'.format(check_obj._val, e)) from e
 
 
 def is_not_uuid1(check_obj):
     try:
         assert UUID(check_obj._val).version != 1
         return check_obj
-    except ValueError:  # check_obj._val is not a UUID at all
-        raise CheckError('{} is not a valid uuid'.format(check_obj._val))
-    except:  # check_obj._val is a UUID, but is indeed v1
-        raise CheckError('{} is a uuid1'.format(check_obj._val))
+    except ValueError as ve:  # check_obj._val is not a UUID at all
+        raise CheckError('{} is not a valid uuid'.format(check_obj._val)) from ve
+    except Exception as e:  # check_obj._val is a UUID, but is indeed v1
+        raise CheckError('{} is a uuid1'.format(check_obj._val)) from e
 
 
 def is_uuid4(check_obj):
     try:
         assert (UUID(check_obj.value).version == 4)
         return check_obj
-    except (AssertionError, AttributeError, ValueError):
-        raise CheckError('{} is not a valid uuid4'.format(check_obj._val))
+    except (AssertionError, AttributeError, ValueError) as e:
+        raise CheckError('{} is not a valid uuid4'.format(check_obj._val)) from e
 
 
 def is_not_uuid4(check_obj):
     try:
         assert UUID(check_obj._val).version != 4
         return check_obj
-    except ValueError:  # check_obj._val is not a UUID at all
-        raise CheckError('{} is not a valid uuid'.format(check_obj._val))
-    except:  # check_obj._val is a UUID, but is indeed v4
-        raise CheckError('{} is a uuid4'.format(check_obj._val))
+    except ValueError as ve:  # check_obj._val is not a UUID at all
+        raise CheckError('{} is not a valid uuid'.format(check_obj._val)) from ve
+    except Exception as e:  # check_obj._val is a UUID, but is indeed v4
+        raise CheckError('{} is a uuid4'.format(check_obj._val)) from e


### PR DESCRIPTION
Currently when an assert fails, we get this error: 

**During handling of the above exception, another exception occurred**

That seems like one thing broke the other. Adding a simple `raise EX from base_ex` changes the error to something much nicer:

**The above exception was the direct cause of the following exception:**

```
    def test_add_by_primary_key():
        sd = SearchDict()
        sd[7] = "User 7"
        sd[8] = "User 8"
>       Is(len(sd)).length(2)
```

This PR adds a ton of `raise from`s