### PR TITLE
Add Check(dict).has_pairs

### DIFF
--- a/fluentcheck/assertions_check/dicts.py
+++ b/fluentcheck/assertions_check/dicts.py
@@ -40,3 +40,22 @@ def has_not_keys(check_obj, *args):
         return check_obj
     except AssertionError as e:
         raise CheckError('{} does contains key: {}'.format(check_obj._val, cur_key)) from e
+
+def has_pairs(check_obj, expected_pairs):
+    check_obj.is_dict()
+    try:
+        for cur_key, cur_value in expected_pairs.items():
+            assert check_obj.value[cur_key] == cur_value
+        return check_obj
+    except (KeyError, AssertionError) as e:
+        raise CheckError('{} does not contain pair: {}:{}'.format(check_obj._val, cur_key, cur_value)) from e
+
+def has_not_pairs(check_obj, expected_pairs):
+    check_obj.is_dict()
+    try:
+        for cur_key, cur_value in expected_pairs.items():
+            does_not_have_key = cur_key not in check_obj.value.keys()
+            assert does_not_have_key or check_obj.value[cur_key] != cur_value
+        return check_obj
+    except (KeyError, AssertionError) as e:
+        raise CheckError('{} does contain pair: {}:{}'.format(check_obj._val, cur_key, cur_value)) from e

--- a/fluentcheck/tests/tests_check/test_dicts.py
+++ b/fluentcheck/tests/tests_check/test_dicts.py
@@ -43,4 +43,23 @@ class TestDictsAssertions(unittest.TestCase):
         except CheckError:
             pass
 
-    
+    def test_has_pairs(self):
+        d = { 1: 'one', 2: 'two'}
+        res = Check(d).has_pairs({1: 'one'})
+        self.assertIsInstance(res, Check)
+        try:
+            Check(d).has_pairs({3: 'three'})
+            self.fail()
+        except CheckError:
+            pass
+
+    def test_has_not_pairs(self):
+        d = { 1: 'one', 2: 'two'}
+        res = Check(d).has_not_pairs({3: 'three'})
+        self.assertIsInstance(res, Check)
+        try:
+            Check(d).has_not_pairs({1: 'one'})
+            self.fail()
+        except CheckError:
+            pass
+


### PR DESCRIPTION
This pull request adds Check.add_pairs which allows checking that a dict
contains all of the expected key/value pairs

For example:

d = {1: "one", 2: "two"}
Check(d).has_pairs({1: "one"})
Check(d).has_pairs({3: "three"}) # raises error

has_not_pairs is also implemented

d = {1: "one", 2: "two"}
Check(d).has_not_pairs({3: "three"})
Check(d).has_pairs({1: "one"}) # raises error